### PR TITLE
Adjust XP per task difficulty

### DIFF
--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -17,6 +17,7 @@ interface CreateTaskData {
   estimated_duration?: number;
   tags?: string[];
   notes?: string;
+  xp_reward?: number;
 }
 
 export const useTasks = () => {
@@ -107,7 +108,10 @@ export const useTasks = () => {
   const createTask = async (taskData: CreateTaskData) => {
     if (!user) return;
 
-    const xpReward = calculateXPReward(taskData.difficulty);
+    const xpReward =
+      typeof taskData.xp_reward === 'number'
+        ? taskData.xp_reward
+        : calculateXPReward(taskData.difficulty);
 
     try {
       const { data, error } = await supabase

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,6 +15,7 @@ import { useAppSettings } from "@/hooks/useAppSettings";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { LogOut, Plus } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
 
 const Index = () => {
   const { user, loading: authLoading, signOut } = useAuth();
@@ -80,32 +81,28 @@ const Index = () => {
   };
 
   const handleCreateDemoTasks = async () => {
-    const demoTasks = [
-      {
-        title: "Hacer 30 minutos de ejercicio",
-        description: "Cualquier actividad física que te haga sudar",
-        category: "Salud",
-        difficulty: "normal" as const,
-        estimated_duration: 30,
-      },
-      {
-        title: "Leer 20 páginas de un libro",
-        description: "Continúa con tu lectura actual o empieza uno nuevo",
-        category: "Aprendizaje",
-        difficulty: "easy" as const,
-        estimated_duration: 45,
-      },
-      {
-        title: "Meditar 10 minutos",
-        description: "Practica mindfulness o meditación guiada",
-        category: "Bienestar",
-        difficulty: "easy" as const,
-        estimated_duration: 10,
-      },
-    ];
+    const { data, error } = await supabase.from('demo_tasks').select('*');
+
+    if (error) {
+      console.error('Error fetching demo tasks:', error);
+      toast.error('No se pudieron cargar las tareas de ejemplo');
+      return;
+    }
+
+    const demoTasks = data || [];
 
     for (const task of demoTasks) {
-      await createTask(task);
+      await createTask({
+        title: task.title,
+        description: task.description || undefined,
+        category: task.category,
+        priority: task.priority || undefined,
+        difficulty: task.difficulty || undefined,
+        estimated_duration: task.estimated_duration || undefined,
+        tags: task.tags || undefined,
+        notes: task.notes || undefined,
+        xp_reward: task.xp_reward,
+      });
     }
 
     toast.success("¡Tareas de ejemplo creadas!");

--- a/supabase/seed/demo_tasks.csv
+++ b/supabase/seed/demo_tasks.csv
@@ -1,0 +1,21 @@
+title,description,category,difficulty,estimated_duration,xp_reward
+Hacer 30 minutos de ejercicio,Cualquier actividad física que te haga sudar,Salud,normal,30,50
+Leer 20 páginas de un libro,Continúa con tu lectura actual o empieza uno nuevo,Aprendizaje,easy,45,30
+Meditar 10 minutos,Practica mindfulness o meditación guiada,Bienestar,easy,10,30
+Beber 8 vasos de agua,Mantente hidratado durante el día,Salud,easy,0,30
+Escribir en un diario,Reflexiona sobre tu jornada y sentimientos,Bienestar,normal,15,50
+Planear el día,Define las tareas y objetivos principales,Organización,normal,20,50
+Preparar una comida saludable,Cocina algo nutritivo y equilibrado,Salud,normal,60,50
+"Caminar 10,000 pasos",Realiza caminatas a lo largo del día,Salud,hard,90,100
+Aprender una nueva habilidad,Dedica tiempo a un curso o tutorial,Aprendizaje,normal,60,50
+Limpiar el escritorio,Ordena tu espacio de trabajo,Organización,easy,15,30
+Hacer estiramientos por 15 minutos,Ejercicios básicos de flexibilidad,Salud,easy,15,30
+Dormir 8 horas,Asegura un descanso nocturno adecuado,Bienestar,normal,480,50
+Escuchar un podcast educativo,Elige un tema que amplíe tu conocimiento,Aprendizaje,easy,30,30
+Revisar metas semanales,Evalúa tu progreso y ajusta objetivos,Productividad,normal,20,50
+Organizar archivos en la computadora,Clasifica y respalda documentos importantes,Productividad,easy,30,30
+Practicar un hobby creativo,"Pinta, escribe o toca un instrumento",Creatividad,normal,45,50
+Llamar a un amigo o familiar,Fortalece tus relaciones personales,Social,easy,10,30
+Tomar un descanso de pantalla de 30 minutos,Aléjate de dispositivos electrónicos,Bienestar,easy,30,30
+Realizar una tarea de voluntariado,Colabora con tu comunidad o entorno,Social,hard,120,100
+Hacer seguimiento de gastos diarios,Anota tus compras para controlar tu presupuesto,Finanzas,normal,15,50


### PR DESCRIPTION
## Summary
- update `demo_tasks.csv` so XP rewards scale with task difficulty
- load demo tasks from DB in `handleCreateDemoTasks`
- allow passing explicit XP on create

## Testing
- `npm install`
- `npm run lint` *(fails: 7 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684d4b868e68832787e2d183109654d0