### PR TITLE
Fix duplicate signup handling

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,11 +52,15 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return () => subscription.unsubscribe();
   }, []);
 
-  const signUp = async (email: string, password: string, username?: string) => {
+  const signUp = async (
+    email: string,
+    password: string,
+    username?: string,
+  ) => {
     // Usar la URL actual completa para redirect
     const redirectUrl = `${window.location.origin}/confirm-password?confirmed=true`;
 
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -67,7 +71,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         },
       },
     });
-    return { error };
+
+    return { data, error };
   };
 
   const signIn = async (email: string, password: string) => {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -23,9 +23,11 @@ const Auth = () => {
 
     try {
       if (isSignUp) {
-        const { error } = await signUp(email, password, username);
+        const { data, error } = await signUp(email, password, username);
         if (error) {
           toast.error(error.message);
+        } else if (!data?.user) {
+          toast.error('El correo electrónico ya está registrado. Por favor inicia sesión.');
         } else {
           toast.success('¡Cuenta creada! Revisa tu email para confirmar tu cuenta.');
         }


### PR DESCRIPTION
## Summary
- return signup data in `AuthContext` and check for missing user
- show a duplicate email error if sign up succeeds without creating a user

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855659d2f408327bc929665346def40