### PR TITLE
Update signUp redirect URL

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,7 +10,7 @@ interface AuthContextType {
     email: string,
     password: string,
     username?: string
-  ) => Promise<{ error: any }>;
+  ) => Promise<{ data: any; error: any }>;
   signIn: (email: string, password: string) => Promise<{ error: any }>;
   signOut: () => Promise<void>;
 }
@@ -57,8 +57,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     password: string,
     username?: string,
   ) => {
-    // Usar la URL actual completa para redirect
-    const redirectUrl = `${window.location.origin}/confirm-password?confirmed=true`;
+    // Use the current origin for the redirect
+    const redirectUrl = `${window.location.origin}/?confirmed=true`;
 
     const { data, error } = await supabase.auth.signUp({
       email,


### PR DESCRIPTION
## Summary
- adjust `signUp` return type in `AuthContext`
- ensure signup confirmation redirects to the root URL

## Testing
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68556bd68b508327ad82533bab61a6de